### PR TITLE
feat: add Sparse Merkle Tree implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,13 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/stretchr/testify v1.8.3 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,9 +19,13 @@ github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+j
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/multilevelmktree/sparse.go
+++ b/multilevelmktree/sparse.go
@@ -1,0 +1,225 @@
+/*
+Package implements a sparse Merkle tree data structure.
+
+The SparseMerkleTree struct represents a sparse Merkle tree and contains the
+root node, depth, and a map of leaves. The MerklePathItem struct represents an
+item in the Merkle tree path.
+
+The package provides the following functions and methods:
+
+Functions:
+- getHashEmptyForDepth(depth int) *big.Int: Calculates the hash value for an
+  empty node at a given depth.
+- getPaddedBinaryString(i int, depth int) string: Returns a binary string
+  representation of an integer, padded with leading zeros to a specified length.
+- NewDeterministicSparseMerkleTree(depth int) *SparseMerkleTree: Creates a new
+  deterministic sparse Merkle tree with non-null leaves.
+
+Methods:
+- NewSparseMerkleTree(depth int) *SparseMerkleTree: Creates a new sparse Merkle
+  tree with empty leaves.
+- (smt *SparseMerkleTree) Insert(key string, value *big.Int): Inserts a leaf
+  with the given key and value into the tree.
+- (smt *SparseMerkleTree) GenerateMerklePath(key string) ([]*MerklePathItem,
+  error): Generates a Merkle tree path for the leaf with the given key.
+- VerifyMerklePath(leafHash *big.Int, path []*MerklePathItem, expectedRoot
+  *big.Int) bool: Verifies a Merkle tree path against the expected root hash.
+
+Methods (internal):
+- (node *MerkleNode) getLeftChild(depth int) *MerkleNode: Returns the left child
+  node of the current node.
+- (node *MerkleNode) getRightChild(depth int) *MerkleNode: Returns the right
+  child node of the current node.
+- hashChildren(left, right *MerkleNode, depth int) *big.Int: Computes the hash
+  value of two child nodes.
+- getPathBit(key string, depth int) int: Retrieves the bit value of the key at
+  the specified depth.
+
+Note: The code provided here has been enhanced with comments explaining the
+purpose of each function and method.
+*/
+
+package multilevelmktree
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+
+	"github.com/iden3/go-iden3-crypto/poseidon"
+)
+
+// SparseMerkleTree represents a sparse Merkle tree.
+type SparseMerkleTree struct {
+	Root   *MerkleNode
+	Depth  int
+	Leaves map[string]*big.Int
+}
+
+// MerklePathItem represents an item in the Merkle tree path.
+type MerklePathItem struct {
+	SiblingHash *big.Int
+	IsRight     bool
+}
+
+var zeroLeaf, _ = poseidon.Hash([]*big.Int{big.NewInt(0)})
+
+// getHashEmptyForDepth calculates the hash value for an empty node at a given
+// depth.
+func getHashEmptyForDepth(depth int) *big.Int {
+	h := zeroLeaf
+	for i := 0; i < depth; i++ {
+		h, _ = poseidon.Hash([]*big.Int{h, h})
+	}
+	return h
+}
+
+// NewSparseMerkleTree creates a new sparse Merkle tree with empty leaves.
+func NewSparseMerkleTree(depth int) *SparseMerkleTree {
+	emptyLeaves := make(map[string]*big.Int)
+	root := &MerkleNode{Data: getHashEmptyForDepth(depth)}
+	return &SparseMerkleTree{Root: root, Depth: depth, Leaves: emptyLeaves}
+}
+
+// Insert inserts a leaf with the given key and value into the tree.
+func (smt *SparseMerkleTree) Insert(key string, value *big.Int) {
+	smt.Leaves[key] = value
+	smt.Root = smt.insertIntoNode(smt.Root, key, value, 0, smt.Depth)
+}
+
+// insertIntoNode inserts a leaf into the given node at the specified depth.
+func (smt *SparseMerkleTree) insertIntoNode(node *MerkleNode, key string, value *big.Int, depth, maxDepth int) *MerkleNode {
+	if node == nil {
+		node = &MerkleNode{Data: getHashEmptyForDepth(maxDepth - depth)}
+	}
+
+	if depth == maxDepth {
+		return &MerkleNode{Data: value}
+	}
+
+	pathBit := getPathBit(key, depth)
+	if pathBit == 0 {
+		node.Left = smt.insertIntoNode(node.getLeftChild(depth+1), key, value, depth+1, maxDepth)
+	} else {
+		node.Right = smt.insertIntoNode(node.getRightChild(depth+1), key, value, depth+1, maxDepth)
+	}
+
+	node.Data = hashChildren(node.Left, node.Right, maxDepth-depth)
+	return node
+}
+
+// GenerateMerklePath generates a Merkle tree path for the leaf with the given key.
+func (smt *SparseMerkleTree) GenerateMerklePath(key string) ([]*MerklePathItem, error) {
+	if _, exists := smt.Leaves[key]; !exists {
+		return nil, fmt.Errorf("no leaf exists at key: %s", key)
+	}
+
+	path := make([]*MerklePathItem, smt.Depth)
+	current := smt.Root
+	for depth := 0; depth < smt.Depth; depth++ {
+		pathBit := getPathBit(key, depth)
+		if pathBit == 0 {
+			path[depth] = &MerklePathItem{
+				SiblingHash: current.getRightChild(depth + 1).Data,
+				IsRight:     true,
+			}
+			current = current.getLeftChild(depth + 1)
+		} else {
+			path[depth] = &MerklePathItem{
+				SiblingHash: current.getLeftChild(depth + 1).Data,
+				IsRight:     false,
+			}
+			current = current.getRightChild(depth + 1)
+		}
+	}
+
+	// Reverse path
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	return path, nil
+}
+
+// VerifyMerklePath verifies a Merkle tree path against the expected root hash.
+func VerifyMerklePath(leafHash *big.Int, path []*MerklePathItem, expectedRoot *big.Int) bool {
+	currentHash := leafHash
+	for _, item := range path {
+		siblingHash := item.SiblingHash
+
+		if item.IsRight {
+			currentHash, _ = poseidon.Hash([]*big.Int{currentHash, siblingHash})
+			fmt.Println("currentHash", currentHash, "siblingHash", siblingHash)
+		} else {
+			currentHash, _ = poseidon.Hash([]*big.Int{siblingHash, currentHash})
+		}
+	}
+
+	return currentHash.Cmp(expectedRoot) == 0
+}
+
+// getLeftChild returns the left child node of the current node.
+func (node *MerkleNode) getLeftChild(depth int) *MerkleNode {
+	if node.Left == nil {
+		return &MerkleNode{Data: getHashEmptyForDepth(depth), Left: nil, Right: nil}
+	}
+	return node.Left
+}
+
+// getRightChild returns the right child node of the current node.
+func (node *MerkleNode) getRightChild(depth int) *MerkleNode {
+	if node.Right == nil {
+		return &MerkleNode{Data: getHashEmptyForDepth(depth), Left: nil, Right: nil}
+	}
+	return node.Right
+}
+
+// hashChildren computes the hash value of two child nodes.
+func hashChildren(left, right *MerkleNode, depth int) *big.Int {
+	leftData := getHashEmptyForDepth(depth - 1)
+	rightData := getHashEmptyForDepth(depth - 1)
+
+	if left != nil {
+		leftData = left.Data
+	}
+
+	if right != nil {
+		rightData = right.Data
+	}
+
+	hash, _ := poseidon.Hash([]*big.Int{leftData, rightData})
+	return hash
+}
+
+// getPathBit retrieves the bit value of the key at the specified depth.
+func getPathBit(key string, depth int) int {
+	if len(key) == 0 {
+		return 0
+	}
+	i, _ := strconv.Atoi(key[depth : depth+1])
+	return i
+}
+
+// getPaddedBinaryString returns a binary string representation of an integer,
+// padded with leading zeros to a specified length.
+func getPaddedBinaryString(i int, depth int) string {
+	binStr := strconv.FormatInt(int64(i), 2)
+	for len(binStr) < depth {
+		binStr = "0" + binStr
+	}
+	return binStr
+}
+
+// NewDeterministicSparseMerkleTree creates a new deterministic sparse Merkle tree with non-null leaves.
+func NewDeterministicSparseMerkleTree(depth int) *SparseMerkleTree {
+	numLeaves := int(math.Pow(2, float64(depth)))
+	smt := NewSparseMerkleTree(depth)
+	for i := 0; i < numLeaves; i++ {
+		key := getPaddedBinaryString(i, depth)
+		leaf := big.NewInt(int64(i))
+		smt.Insert(key, leaf)
+	}
+
+	return smt
+}

--- a/multilevelmktree/sparse_test.go
+++ b/multilevelmktree/sparse_test.go
@@ -1,0 +1,141 @@
+package multilevelmktree
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSparseMerkleTree(t *testing.T) {
+	smt := NewSparseMerkleTree(2)
+	assert.NotNil(t, smt)
+	assert.NotNil(t, smt.Root)
+	assert.Equal(t, 2, smt.Depth)
+	assert.Empty(t, smt.Leaves)
+
+	tests := []struct {
+		key          string
+		value        *big.Int
+		expectedRoot string
+	}{
+		{
+			key:          "00",
+			value:        big.NewInt(0),
+			expectedRoot: "18366138217714291923534712849449091358386817997964088830897385671725623871073",
+		},
+		{
+			key:          "01",
+			value:        big.NewInt(1),
+			expectedRoot: "8029606767784791880250783890079025673413177318829731918696248003381461757603",
+		},
+		{
+			key:          "10",
+			value:        big.NewInt(2),
+			expectedRoot: "16218640559429857690153995608944582618510520484403789436977896806380962629939",
+		},
+		{
+			key:          "11",
+			value:        big.NewInt(3),
+			expectedRoot: "3720616653028013822312861221679392249031832781774563366107458835261883914924",
+		},
+	}
+
+	initRoot := new(big.Int)
+	initRoot.SetString("2186774891605521484511138647132707263205739024356090574223746683689524510919", 10)
+	if smt.Root.Data.Cmp(initRoot) != 0 {
+		t.Error("Expected root node data to be", initRoot, "got", smt.Root.Data)
+	}
+
+	for _, test := range tests {
+		smt.Insert(test.key, test.value)
+		expectedRoot := new(big.Int)
+		expectedRoot.SetString(test.expectedRoot, 10)
+		if smt.Root.Data.Cmp(expectedRoot) != 0 {
+			t.Error("Expected root node data to be", expectedRoot, "got", smt.Root.Data)
+		}
+	}
+}
+
+func TestInsert(t *testing.T) {
+	smt := NewSparseMerkleTree(3)
+
+	key := "000"
+	value := big.NewInt(5)
+
+	smt.Insert(key, value)
+
+	assert.Equal(t, value, smt.Leaves[key])
+}
+
+func TestGetPaddedBinaryString(t *testing.T) {
+	assert.Equal(t, "000", getPaddedBinaryString(0, 3))
+	assert.Equal(t, "001", getPaddedBinaryString(1, 3))
+	assert.Equal(t, "011", getPaddedBinaryString(3, 3))
+	assert.Equal(t, "111", getPaddedBinaryString(7, 3))
+}
+
+func TestNewDeterministicSparseMerkleTree(t *testing.T) {
+	smt := NewDeterministicSparseMerkleTree(3)
+	assert.NotNil(t, smt)
+	assert.NotNil(t, smt.Root)
+	assert.Equal(t, 3, smt.Depth)
+	assert.NotEmpty(t, smt.Leaves)
+	assert.Len(t, smt.Leaves, 8)
+}
+
+// This test will depend on the poseidon.Hash function behavior.
+func TestMerkleNodeHashes(t *testing.T) {
+	smt := NewDeterministicSparseMerkleTree(3)
+
+	// Test the root hash
+	expectedRootHash := smt.Root.Data
+	actualRootHash := hashChildren(smt.Root.Left, smt.Root.Right, smt.Depth)
+
+	assert.Equal(t, expectedRootHash, actualRootHash)
+}
+
+func TestGenerateMerklePath(t *testing.T) {
+	smt := NewDeterministicSparseMerkleTree(4)
+
+	keys := []string{
+		"0000",
+		"0001",
+		"0010",
+		"0100",
+		"1000",
+		"1111",
+	}
+
+	for _, key := range keys {
+		_, err := smt.GenerateMerklePath(key)
+		assert.NoError(t, err, "Should not return an error for key %s", key)
+	}
+
+	// Test with non-existing key
+	_, err := smt.GenerateMerklePath("10101")
+	assert.Error(t, err, "Should return an error for non-existing key")
+}
+
+func TestSparseMerkleTree(t *testing.T) {
+	depth := 4
+	smt := NewDeterministicSparseMerkleTree(depth)
+	fmt.Println(smt.Root.Data)
+	fmt.Println(smt.Leaves)
+
+	// i := 0
+	for i := 0; i < (1 << depth); i++ {
+		key := getPaddedBinaryString(i, depth)
+		value := smt.Leaves[key]
+
+		path, _ := smt.GenerateMerklePath(key)
+		// print []MerklePathItem
+		for _, item := range path {
+			fmt.Println(item)
+		}
+
+		valid := VerifyMerklePath(value, path, smt.Root.Data)
+		assert.True(t, valid, "The Merkle path should be valid for all leaves")
+	}
+}


### PR DESCRIPTION
This commit combines the updates from two separate commits into one, enhancing the Sparse Merkle Tree (SMT) implementation in the `multilevelmktree` package. The following changes have been made:

1. Introducing SparseMerkleTree struct, equipped with methods for insertion, node handling, generating Merkle paths, and verifying Merkle paths.
2. Implementing `NewSparseMerkleTree` and `NewDeterministicSparseMerkleTree` constructors for creating new instances of Sparse Merkle Trees.
3. Adding `Insert` method to facilitate the addition of new leaves to the tree.
4. Incorporating helper functions for hashing and key manipulation.
5. Integrating a thorough suite of unit tests to ensure the correct functionality of the Sparse Merkle Tree.
6. Adding `GenerateMerklePath` method, which constructs a Merkle proof for a specified key within the SMT. The proof consists of a sequence of sibling node hashes, from the leaf node associated with the key up to the root of the tree. This proof enables verification of a key-value pair's presence in the SMT without requiring knowledge of all other key-value pairs.
7. Introducing `VerifyMerklePath` method, which validates the correctness of a provided Merkle proof given a Merkle root, a key-value pair, and the proof. The proof is considered valid if the Merkle root recomputed using the proof and the key-value pair matches the provided Merkle root.

These updates establish a foundation for utilizing the Sparse Merkle Tree, enabling efficient insertion, hashing, key manipulation, generation of Merkle paths, and verification of Merkle proofs.